### PR TITLE
Fix build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/mjbvz/vscode-markdown-image-size/issues"
   },
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.33.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
Currently, this extension won't build as `engines.vscode` is an older version than `@types/vscode`.
Changes made in this PR will fix this matter.